### PR TITLE
Fix integer division issue

### DIFF
--- a/components/trading-page.tsx
+++ b/components/trading-page.tsx
@@ -543,7 +543,7 @@ useEffect(() => {
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <Tabs defaultValue="trade" onValueChange={setActiveTab}>
+                  <Tabs value={activeTab} onValueChange={setActiveTab}>
                     <TabsList className="grid w-full grid-cols-3">
                       <TabsTrigger value="trade">Trade</TabsTrigger>
                       <TabsTrigger value="withdraw">Withdraw</TabsTrigger>

--- a/contracts/ZetaOrderBook.sol
+++ b/contracts/ZetaOrderBook.sol
@@ -273,7 +273,7 @@ contract ZetaOrderBook is UniversalContract {
         // get the owner of the order
         address orderOwner = orders[orderId].owner;
         uint256 usdcAmount = userUsdcBalance[orderOwner];
-        uint256 zetaToBuyAmount = (usdcAmount / targetPriceLow) * 1e18; 
+        uint256 zetaToBuyAmount = usdcAmount * 1e18 / targetPriceLow; 
 
         if (slippageBps > 1000) revert InvalidOrder(); // Max 10% slippage
 


### PR DESCRIPTION
When an order flips from sell to buy, it incorrectly calculates the zetaToBuyAmount.
```solidity
        uint256 zetaToBuyAmount = (usdcAmount / targetPriceLow) * 1e18; // This is probematic, and results in truncation before shifting the decimal place.
```

This was encountered in TX `0xdfe57930c4ea2d0dd9b9a0ef6fb0c7135aece2b31ab913101aefe5ebac2bc4dd`